### PR TITLE
Only copy Samples folder if it doesn't already exist

### DIFF
--- a/VSMacros-VSIX/ReleaseNotes.txt
+++ b/VSMacros-VSIX/ReleaseNotes.txt
@@ -13,3 +13,7 @@ Date: 5/11/2016
 - Added keyboard accelerators for menu items.
 - Added key binding for "Save Current Macro" (Ctrl-M, S)
 - Updated key binding for "Playback" (Ctrl-M, Enter)
+
+Version: 1.1.1
+Date: 5/13/2016
+- Fix issues with Samples initialization

--- a/VSMacros/Engines/Manager.cs
+++ b/VSMacros/Engines/Manager.cs
@@ -380,7 +380,7 @@ namespace VSMacros.Engines
             }
 
             // Recreate file system to ensure that the required files exist
-            this.CreateFileSystem(false);
+            this.CreateFileSystem();
 
             MacroFSNode.RefreshTree();
 
@@ -554,7 +554,7 @@ namespace VSMacros.Engines
             node.IsEditable = true;
         }
 
-        public void CreateFileSystem(bool initial)
+        public void CreateFileSystem()
         {
             // Create main macro directory
             if (!Directory.Exists(VSMacrosPackage.Current.MacroDirectory))
@@ -571,34 +571,24 @@ namespace VSMacros.Engines
             // Create current macro file
             this.CreateCurrentMacro();
 
-            // Create the rest of the file system in a background thread
-            //Task.Run(() =>
-            //{
-                // Create shortcuts file
-                this.CreateShortcutFile();
+            // Create shortcuts file
+            this.CreateShortcutFile();
 
-                if (initial)
-                {
-                    /* Sample folder */
-                    string source = Path.Combine(VSMacrosPackage.Current.AssemblyDirectory, "Macros", "Samples");
-                    string target = Manager.SamplesFolderPath;
+            // Copy Samples folder
+            string samplesTargetDir = SamplesFolderPath;
+            if (!Directory.Exists(samplesTargetDir))
+            {
+                string samplesSourceDir = Path.Combine(VSMacrosPackage.Current.AssemblyDirectory, "Macros", "Samples");
+                DirectoryCopy(samplesSourceDir, samplesTargetDir, true);
+            }
 
-                    // Delete Samples folder
-                    Manager.DeleteFileOrFolder(target);
-
-                    // Copy the Samples folder back
-                    Manager.DirectoryCopy(source, target, true);
-
-                    /* DTE IntelliSense */
-                    source = Path.Combine(VSMacrosPackage.Current.AssemblyDirectory, "Intellisense", Manager.IntellisenseFileName);
-                    target = Manager.IntellisensePath;
-                    if (!File.Exists(target))
-                    {
-                        File.Copy(source, target);
-                    }
-                }
-           // }
-           //);
+            // Copy DTE IntelliSense file
+            string dteFileTargetPath = IntellisensePath;
+            if (!File.Exists(dteFileTargetPath))
+            {
+                string dteFileSourcePath = Path.Combine(VSMacrosPackage.Current.AssemblyDirectory, "Intellisense", IntellisenseFileName);
+                File.Copy(dteFileSourcePath, dteFileTargetPath);
+            }
         }
 
         public void Close()

--- a/VSMacros/Tool Window Components/MacrosToolWindow.cs
+++ b/VSMacros/Tool Window Components/MacrosToolWindow.cs
@@ -39,7 +39,7 @@ namespace VSMacros
             // Instantiate Tool Window Toolbar
             this.ToolBar = new CommandID(GuidList.GuidVSMacrosCmdSet, PkgCmdIDList.MacrosToolWindowToolbar);
 
-            Manager.Instance.CreateFileSystem(true);
+            Manager.Instance.CreateFileSystem();
 
             string macroDirectory = Manager.MacrosPath;
 


### PR DESCRIPTION
[Fix for Issue #9 and Issue #15]
- Samples folder appearing in recycle bin.
- Edits to Samples being lost after VS restart.
Now Samples never deleted. And only copied if directory is missing.