### PR TITLE
Fix fun samples

### DIFF
--- a/VSMacros/Macros/Samples/Fun/Camel.js
+++ b/VSMacros/Macros/Samples/Fun/Camel.js
@@ -1,6 +1,9 @@
 ﻿/* Spawns a zombie that will eat your bad code RAWRRRRR.
  This macro is dedicated to our manager Anson Horton. */
 
+if (dte.UndoContext.IsOpen)
+    dte.UndoContext.Close();
+
 dte.UndoContext.Open("Camel");
 
 var camel =
@@ -17,6 +20,7 @@ var camel =
 
 Macro.InsertText("/*\n*/");
 dte.ExecuteCommand("Edit.LineOpenAbove");
+dte.ActiveDocument.Selection.StartOfLine();
 Macro.InsertText(camel);
 
 dte.UndoContext.Close();

--- a/VSMacros/Macros/Samples/Fun/Zombie.js
+++ b/VSMacros/Macros/Samples/Fun/Zombie.js
@@ -1,6 +1,9 @@
 ﻿/* Spawns a zombie that will eat your bad code RAWRRRRR.
  This macro is dedicated to our manager Anson Horton. */
 
+if (dte.UndoContext.IsOpen)
+    dte.UndoContext.Close();
+
 dte.UndoContext.Open("Zombie");
 
 var zombie =
@@ -28,5 +31,6 @@ var zombie =
 
 Macro.InsertText("/*\n*/");
 dte.ExecuteCommand("Edit.LineOpenAbove");
+dte.ActiveDocument.Selection.StartOfLine();
 Macro.InsertText(zombie);
 dte.UndoContext.Close();


### PR DESCRIPTION
Only close UndoContext if it's already open.
Ensure that text starts printing from the beginning of the line.