### PR TITLE
[Fix for issue #19] Add all MacroCommand# buttons to the Macros menu.

### DIFF
--- a/VSMacros/VSMacros.vsct
+++ b/VSMacros/VSMacros.vsct
@@ -83,6 +83,11 @@
         <Parent guid="guidVSMacrosCmdSet" id="MacrosMenu"/>
       </Group>
 
+      <!-- Pre-defined Macros Group : eg. MacroCommand1, MacroCommand2 -->
+      <Group guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" priority="0x0800">
+        <Parent guid="guidVSMacrosCmdSet" id="MacrosMenu"/>
+      </Group>
+
       <!-- Management group -->
       <Group guid="guidVSMacrosCmdSet" id="MacrosManagementGroup" priority="0x0900">
         <Parent guid="guidVSMacrosCmdSet" id="MacrosToolWindowToolbar"/>
@@ -233,15 +238,60 @@
       <!-- Buttons added through command placements -->
       
       <!-- Macro Shortcut Commands Button -->
-      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand1" priority="00" type="Button"><Strings><ButtonText>MacroCommand1</ButtonText></Strings></Button>
-      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand2" priority="01" type="Button"><Strings><ButtonText>MacroCommand2</ButtonText></Strings></Button>
-      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand3" priority="02" type="Button"><Strings><ButtonText>MacroCommand3</ButtonText></Strings></Button>
-      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand4" priority="03" type="Button"><Strings><ButtonText>MacroCommand4</ButtonText></Strings></Button>
-      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand5" priority="04" type="Button"><Strings><ButtonText>MacroCommand5</ButtonText></Strings></Button>
-      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand6" priority="05" type="Button"><Strings><ButtonText>MacroCommand6</ButtonText></Strings></Button>
-      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand7" priority="06" type="Button"><Strings><ButtonText>MacroCommand7</ButtonText></Strings></Button>
-      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand8" priority="07" type="Button"><Strings><ButtonText>MacroCommand8</ButtonText></Strings></Button>
-      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand9" priority="08" type="Button"><Strings><ButtonText>MacroCommand9</ButtonText></Strings></Button>
+      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand1" priority="00" type="Button">
+        <Parent guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" />
+        <Strings>
+          <ButtonText>Macro Command &amp;1</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand2" priority="01" type="Button">
+        <Parent guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" />
+        <Strings>
+          <ButtonText>Macro Command &amp;2</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand3" priority="02" type="Button">
+        <Parent guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" />
+        <Strings>
+          <ButtonText>Macro Command &amp;3</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand4" priority="03" type="Button">
+        <Parent guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" />
+        <Strings>
+          <ButtonText>Macro Command &amp;4</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand5" priority="04" type="Button">
+        <Parent guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" />
+        <Strings>
+          <ButtonText>Macro Command &amp;5</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand6" priority="05" type="Button">
+        <Parent guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" />
+        <Strings>
+          <ButtonText>Macro Command &amp;6</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand7" priority="06" type="Button">
+        <Parent guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" />
+        <Strings>
+          <ButtonText>Macro Command &amp;7</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand8" priority="07" type="Button">
+        <Parent guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" />
+        <Strings>
+          <ButtonText>Macro Command &amp;8</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidVSMacrosCmdSet" id="cmdidMacroCommand9" priority="08" type="Button">
+        <Parent guid="guidVSMacrosCmdSet" id="PredefinedMacrosGroup" />
+        <Strings>
+          <ButtonText>Macro Command &amp;9</ButtonText>
+        </Strings>
+      </Button>
 
       <!-- Enable TYPECHAR command -->
       <Button guid="guidStd2kCmdSet" id="TYPECHAR" priority="0x0000" type="Button">
@@ -443,6 +493,7 @@
       <!-- Groups -->
       <IDSymbol name="MacrosControlGroup"     value="0x1100"/>
       <IDSymbol name="MacrosActionGroup"      value="0x1200"/>
+      <IDSymbol name="PredefinedMacrosGroup"  value="0x1250"/>
       <IDSymbol name="MacrosManagementGroup"  value="0x1300"/>
 
       <IDSymbol name="CurrentContextGroup"  value="0x1405"/>


### PR DESCRIPTION
Created new sub-menu under Tools.Macros for Pre-defined macro commands (PredefinedMacrosGroup).
Commands still appear as Tools.MacroCommand1, etc in Tools.Options.