### PR TITLE
Upgrade2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/
 [Bb]in/
 [Oo]bj/
 VS2015
+.vs
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/
@@ -159,3 +160,6 @@ $RECYCLE.BIN/
 # JetBrains project files
 .idea
 *.iml
+
+#TabsStudio
+*.tss

--- a/VSMacros-VSIX/source.extension.vsixmanifest
+++ b/VSMacros-VSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="17f25bfa-a812-4b6a-a07e-7f73aa975f8b" Version="1.3.0" Language="en-US" Publisher="Microsoft Corporation" />
+    <Identity Id="17f25bfa-a812-4b6a-a07e-7f73aa975f8b" Version="1.3.0.5" Language="en-US" Publisher="Microsoft Corporation" />
     <DisplayName>Macros for Visual Studio</DisplayName>
     <Description xml:space="preserve">An extension for Visual Studio that enables the use of macros in the IDE. The extension can record most of the features in Visual Studio including text editing operations. Currently built to run on Visual Studio 2013 and Visual Studio 2015.</Description>
     <MoreInfo>https://visualstudiogallery.msdn.microsoft.com/d3fbf133-e51b-41a2-b86f-9560a96ff62b</MoreInfo>


### PR DESCRIPTION
This seems to be working fine. 

- the solution round-trips between 2015 & 2017
- the vsix can be generated by either 2015 or 2017
- the generated vsix can be installed in 2015 & 2017
- the tool window is present and can be opened in 2015 & 2017
- limited testing indicates that it functions correctly in both 2015 & 2017